### PR TITLE
Remove update check

### DIFF
--- a/Admin/Templates/login.tpl
+++ b/Admin/Templates/login.tpl
@@ -11,7 +11,7 @@
 #################################################################################
 
 ############ Check Update #############
-copy("http://travian.gamingcrazy.net/Update/update_latest.tpl", "Templates/update_latest.tpl");
+//copy("http://travian.gamingcrazy.net/Update/update_latest.tpl", "Templates/update_latest.tpl");
 
 ?>
 <div align="center">

--- a/Admin/Templates/update.tpl
+++ b/Admin/Templates/update.tpl
@@ -1,10 +1,10 @@
 <?php
 if($_SESSION['access'] < ADMIN) die("Access Denied: You are not Admin!");
 include('ver.tpl');
-if(isset($_GET['c']))
-{
-	copy("https://raw.github.com/yi12345/TravianZ/master/Admin/Templates/update_latest.tpl", "Templates/update_latest.tpl");
-}
+//if(isset($_GET['c']))
+//{
+//	copy("https://raw.github.com/yi12345/TravianZ/master/Admin/Templates/update_latest.tpl", "Templates/update_latest.tpl");
+//}
 include('update_latest.tpl');
 /*
 if(isset($_GET['u']))

--- a/Admin/Templates/update_latest.tpl
+++ b/Admin/Templates/update_latest.tpl
@@ -1,3 +1,3 @@
 <?php
-$latest="15";
+$latest="16";
 ?>

--- a/Admin/admin.php
+++ b/Admin/admin.php
@@ -97,7 +97,7 @@ $up_avl = $latest - $ver ;
 												<a href="<?php echo HOMEPAGE; ?>">Server Homepage</a>
 												<a href="admin.php">Control Panel Home</a>
 												<a href="<?php echo SERVER; ?>dorf1.php">Return to the server</a>
-												<a href="?p=update"><font color="Red"><b>Server Update (<?php echo $up_avl; ?>)</font></b></a>
+												<!-- <a href="?p=update"><font color="Red"><b>Server Update (<?php echo $up_avl; ?>)</font></b></a>-->
 												<br />
 												<a href="?action=logout">Logout</a>
 												<br />


### PR DESCRIPTION
References to an unavailable site causing errors when accessing the ACP - commented out.

Amended update_latest.tpl to match ver.tpl to fix problem with the ACP showing -1 updates available but then also commented out the 'Server Update' link from the admin menu completely.

I commented these out rather than remove the code so that they can be added back in easily in future if we want a server upgrade option (bad idea IMO as we should be using git for updating).
If we do want this option, need to decide where to point this to as current links point to yi's repo.

---

Edited to remove link to the unavailable site as these comments will be spidered by search engines.
