### PR TITLE
Don't show message about artefacts

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -2489,7 +2489,9 @@ class Automation {
                                     }
                                 }    
                             }else {
-                                $info_hero = $hero_pic.",Your hero could not claim the artefact during raid".$xp;
+                                if (!empty($artifact)) {
+                                    $info_hero = $hero_pic.",Your hero could not claim the artefact during raid".$xp;
+                                }
                             }
                         }
                     }elseif($data['t11']>0) {


### PR DESCRIPTION
Don't show message about artefacts when raiding a village that doesn't have them.

This cures Issue #27 for me but should be tested on servers where artefacts have been released before merging (no artes on my test server yet).
