### PR TITLE
Fixed choose two targets for catapults by Armando

### DIFF
--- a/Templates/a2b/attack.tpl
+++ b/Templates/a2b/attack.tpl
@@ -248,7 +248,7 @@ $end = ($tribe*10);
                             <?php } ?>
                         </select>
 
-            <?php if($building->getTypeLevel(16) == 20) { ?>
+            <?php if($building->getTypeLevel(16) == 20 && $process['t8'] >= 20) { ?>
                      <select name="ctar2" class="dropdown">
                 <option value="0">-</option>
                 <option value="99">Random</option>


### PR DESCRIPTION
With a level 20 rally point two buildings can be targeted at the same time. You just need to attack with at least 20 catapults to be able to choose two targets.
http://t3.answers.travian.us/
