### PR TITLE
Building bugs

### DIFF
--- a/build.php
+++ b/build.php
@@ -37,7 +37,7 @@ if(isset($_GET['id'])) {
 	if (!ctype_digit(preg_replace("/[^a-zA-Z0-9_-]/","",$_GET['id']))){
 		$_GET['id'] = "1";
 	}
-	$checkBuildings = array(0,17,25,26,27);
+	$checkBuildings = array(0,16,17,25,26,27);
 	if($_GET['id'] < 19 || !in_array($_GET['gid'], $checkBuildings)){
 	    $_GET['t'] = "";
 	    $_GET['s'] = "";

--- a/build.php
+++ b/build.php
@@ -37,6 +37,11 @@ if(isset($_GET['id'])) {
 	if (!ctype_digit(preg_replace("/[^a-zA-Z0-9_-]/","",$_GET['id']))){
 		$_GET['id'] = "1";
 	}
+	$checkBuildings = array(0,17,25,26,27);
+	if($_GET['id'] < 19 || !in_array($_GET['gid'], $checkBuildings)){
+	    $_GET['t'] = "";
+	    $_GET['s'] = "";
+	}
 	if($village->resarray['f'.$_GET['id'].'t'] == 17) {
 		$market->procRemove($_GET);
 	}


### PR DESCRIPTION
This bug is a little hard to meet but It's still there. I found it by trying to use NPC merchant while not having a marketplace. It will show an error. The bug happens everytime you type `build.php?id=5&t=2` . The problem here is `t=` or `s=`, both are used as tabs in certain buildings, but when it has only 1 page it crash.
For example: market has `Send Resources | Buy | Offer | NPC trading`  while clay pit has none. So adding the t= variable to the clay pit would make it display an error.
This is probably not the best way to fix it but it works. Now, there is still another problem, marketplace has 4 tabs, so adding `&t=5` will bug it.
It would be better if you can test it again, just in case I broke somethingelse :P
