### PR TITLE
Building at random positions fix

### DIFF
--- a/GameEngine/Building.php
+++ b/GameEngine/Building.php
@@ -86,9 +86,11 @@ class Building {
             }    
         }
         if(isset($get['a']) && $get['c'] == $session->checker && isset($get['id'])) {
-            $session->changeChecker();
-            $this->canProcess($get['a'],$get['id']);
-            $this->constructBuilding($get['id'],$get['a']);
+            if  ($get['id'] > 18 && ($get['id'] < 41 || $get['id'] == 99)){
+            	$session->changeChecker();
+            	$this->canProcess($get['a'],$get['id']);
+            	$this->constructBuilding($get['id'],$get['a']);
+            }
         }
         if(isset($get['buildingFinish']) && $session->plus) {
             if($session->gold >= 2 && $session->sit == 0) {


### PR DESCRIPTION
Typing something like `dorf2.php?a=25&id=20000&c=d6F` where `id=` is the position in the village will get you an error if the id is higher than 40 ( not including WW id=99). `Unknown column 'f20000t' in 'field list'`  
So I added this restriction when building. Although it fixes the problem, you can still build at WW position, bugging your building and not being able to use, or demolish it.
