### PR TITLE
fix: list of villages out of position on some pages

### DIFF
--- a/a2b.php
+++ b/a2b.php
@@ -241,7 +241,7 @@ if(isset($_GET['o'])) {
 
 ?>
 
-<br /><br /><div id="side_info">
+<br /><br /><br /><br /><div id="side_info">
 <?php
 include("Templates/multivillage.tpl");
 include("Templates/quest.tpl");

--- a/a2b2.php
+++ b/a2b2.php
@@ -342,7 +342,7 @@ $golds1 = mysqli_fetch_array($MyGold);
 
 </div>
 </div>
-<br /><br /><div id="side_info">
+<br /><br /><br /><br /><div id="side_info">
 <?php
 include("Templates/multivillage.tpl");
 include("Templates/quest.tpl");


### PR DESCRIPTION
The same location of the list of villages on all pages in the sidebar.

On some page the list went up. Now he is on the same level.