### PR TITLE
Correcting the description of the building

### DIFF
--- a/gpack/travian_default/lang/en/compact.css
+++ b/gpack/travian_default/lang/en/compact.css
@@ -15,7 +15,7 @@ h1 {
     margin-bottom: 8px;
 }
 p {
-    margin: 14px 0;
+    margin: 20px 0;
     padding: 0;
 }
 label {


### PR DESCRIPTION
Here I will set an example from the server of Martin and mine. The picture crawls on the table. I checked a lot and came to the conclusion that this is the most optimal solution. Since other solutions require too many corrections. Since I can not add images here I opened a new issue for this https://github.com/Shadowss/TravianZ/issues/464 According to my observations, nothing else has worsened anywhere.