### PR TITLE
Fix PHP 7.2 warning count

### DIFF
--- a/GameEngine/Database.php
+++ b/GameEngine/Database.php
@@ -678,7 +678,7 @@ class MYSQLi_DB implements IDbConnection {
             $arrayVariable[$arrayStructure] = [];
         }
 
-        if (isset($arrayVariable[$arrayStructure]) && count($arrayVariable[$arrayStructure])) {
+        if (isset($arrayVariable[$arrayStructure]) && !empty($arrayVariable[$arrayStructure])) {
             return $arrayVariable[$arrayStructure];
         } else {
             return null;

--- a/GameEngine/Database.php
+++ b/GameEngine/Database.php
@@ -5461,7 +5461,7 @@ References: User ID/Message ID, Mode
 				$q = "SELECT * FROM " . TB_PREFIX . "movement, " . TB_PREFIX . "attacks where " . TB_PREFIX . "movement.`" . $where . "` IN(".implode(', ', $village).") and " . TB_PREFIX . "movement.ref = " . TB_PREFIX . "attacks.id and " . TB_PREFIX . "movement.proc = 0 and " . TB_PREFIX . "movement.sort_type = 3 or " . TB_PREFIX . "movement.`" . $where . "` IN(".implode(', ', $village).") and " . TB_PREFIX . "movement.ref = " . TB_PREFIX . "attacks.id and " . TB_PREFIX . "movement.proc = 0 and " . TB_PREFIX . "movement.sort_type = 4 ORDER BY endtime ASC";
 				break;
 			default:
-				return null;
+				return [];
 		}
 
 		$result = $this->mysqli_fetch_all(mysqli_query($this->dblink,$q));

--- a/GameEngine/Multisort.php
+++ b/GameEngine/Multisort.php
@@ -43,8 +43,10 @@ class multiSort {
 					$t = 'strnatcmp($a[' . $key . '], $b[' . $key . '])';
 					break;
 			}
-			usort($array, create_function('$a, $b', 'return ' . ($order ? '' : '-') . '(' . $t . ');'));
 
+			usort($array, function($a, $b) use ($order, $t) {
+				return ($order ? '' : '-') . ($t);
+			});
 		}
 		return $array;
 	}

--- a/GameEngine/Ranking.php
+++ b/GameEngine/Ranking.php
@@ -271,6 +271,8 @@
                     ORDER BY totalpop DESC, totalvillages DESC, userid DESC";
 				}
 
+				$datas = array();
+
 				$result = (mysqli_query($GLOBALS['link'],$q));
 				while($row = mysqli_fetch_assoc($result)) {
 					$datas[] = $row;


### PR DESCRIPTION
Fix PHP 7.2 Warning: count(): Parameter must be an array or an object that implements Countable in GameEngine/Ranking.php on line 279

-------------
Warn when counting non-countable types 

An E_WARNING will now be emitted when attempting to count() non-countable types (this includes the sizeof() alias function).

```
<?php

var_dump(
    count(1), // integers are not countable
    count('abc'), // strings are not countable
    count(new stdclass), // objects not implementing the Countable interface are not countable
    count([1,2]) // arrays are countable
);
  
```