### PR TITLE
Fixed redirecting to the rally point issue #479

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -3213,7 +3213,7 @@ class Automation {
         if(file_exists($autoprefix."GameEngine/Prevention/sendunits.txt")) {
             unlink($autoprefix."GameEngine/Prevention/sendunits.txt");
         }
-        if ($reload) header("Location: ".$_SERVER['PHP_SELF']);
+        if ($reload) header("Location: ".$_SERVER['REQUEST_URI']);
     }
 
     function DelVillage($wref, $mode=0){


### PR DESCRIPTION
This will still raise a problem, if you are posting to a page, let's say you are sending an attack or changing your profile or sending resources, any page where you have posted data in your request. You will be redirected to the same page but your posted data will be gone. 
Of course this will only happen on serves where there are not many requests, this is happening because you happened to be either the defender or the attacker of that movement, and you are the first person to load the game after the attack's time was due. 

In my opinion this line should be gone altogether, there is no need to reload the page since we are not on dorf1 or in rally point, these pages have their own reload functions. But for now, changing it to request_uri will ensure that you won't be redirected to the rally point 