### PR TITLE
Fixed some bugs

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -1675,6 +1675,30 @@ class Automation {
                             }
                         }
                     }
+                    
+                    // we need to save the attacker heroid before the battle
+                    if(isset($Attacker['uhero']) && $Attacker['uhero'] > 0){
+                        $AttackerHeroID = $database->getHeroField($from['owner'],"heroid");
+                    }
+                    
+                    // and the defender(s) heroid
+                    $DefendersHeroID = array();
+                    
+                    // check if our hero is defending the village, if so, add it to the list
+                    if (isset($Defender['hero']) && $Defender['hero'] > 0) {                        
+                        $DefendersHeroID[] = $database->getHeroField($DefenderID, "heroid");
+                    }
+
+                    // check if there are other heroes defending the village
+                    if(count($enforcementarray) > 0){
+                        foreach($enforcementarray as $enforcement){
+                            if($enforcement['hero'] > 0){
+                                $heroOwner = $database->getVillageField($enforcement['from'],"owner");
+                                $DefendersHeroID[] = $database->getHeroField($heroOwner, "heroid");
+                            }                          
+                        }
+                    }
+                    
                     //to battle.php
                     //fix by ronix
                     //MUST TO BE FIX : You need to filter these values
@@ -1693,25 +1717,12 @@ class Automation {
                     }else{
                         $unitssend_att_check=$unitssend_att;
                     }
-                    //units defence string for battleraport
-                    $DefenderHero=array();
-                    $d=0;
-                    if (isset($Defender['hero'])) {
-                        if ($Defender['hero']>0) {
-                            $d=1;
-                            $DefenderHero[$d]=$DefenderID;
-                        }
-                    }
 
                     // our reinforcements count could have changed at this point, thus the re-select
                     $enforcementarray2 = $database->getEnforceVillage($data['to'],0);
                     if(count($enforcementarray2) > 0) {
                         foreach($enforcementarray2 as $enforce2) {
                             $Defender['hero'] += $enforce2['hero'];
-                            if ($enforce2['hero']>0) {
-                                $d++;
-                                $DefenderHero[$d] = $database->getVillageField($enforce2['from'],"owner");
-                            }
                             for ($i=1;$i<=50;$i++) {
                                 $Defender['u'.$i]+= $enforce2['u'.$i];
                             }
@@ -2026,7 +2037,7 @@ class Automation {
 
                     if ($Attacker['uhero'] != 0){
                         $heroxp = $totalpoint_att;
-                        $database->modifyHeroXp("experience",$heroxp,$from['owner']);
+                        $database->modifyHeroXp("experience",$heroxp,$AttackerHeroID);
                     }
 
                     for($i=1;$i<=10;$i++){
@@ -2042,12 +2053,12 @@ class Automation {
                         $totalpoint_def = 0;
                     }
                     $totalpoint_def += $dead11*6;
+                    
                     if($Defender['hero'] > 0){
                         //counting heroxp
-                        $defheroxp=intval($totalpoint_def/count($DefenderHero));
-                        for ($i=1;$i<=count($DefenderHero);$i++){
-                            $reinfheroxp = $defheroxp;
-                            $database->modifyHeroXp("experience",$reinfheroxp,$DefenderHero[$i]);
+                        $defheroxp=intval($totalpoint_def/count($DefendersHeroID));
+                        foreach($DefendersHeroID as $HeroID){
+                            $database->modifyHeroXp("experience",$defheroxp,$HeroID);
                         }
                     }
 
@@ -2258,200 +2269,201 @@ class Automation {
                     } else {
                         $can_destroy=0;
                     }
-                    if ($isoasis == 1) $can_destroy=0;
 
-                    if ($type=='3')
+                    if($isoasis == 0)
                     {
-                        if (($data['t7']-$traped7)>0){
-                            if (isset($empty)){
-                                $info_ram = "".$ram_pic.",There is no wall to destroy.";
-                            } else
-
-                            if ($battlepart[8]>$battlepart[7]){
-                                $info_ram = "".$ram_pic.",Wall destroyed.";
-                                $database->setVillageLevel(
-                                    $data['to'],
-                                    ["f".$wallid, "f".$wallid."t"],
-                                    [0, 0]
-                                );
-                                $pop=$this->recountPop($data['to']);
-
-                            }elseif ($battlepart[8]==0){
-
-                                $info_ram = "".$ram_pic.",Wall was not damaged.";
-                            }else{
-                                $totallvl = round(sqrt(pow(($walllevel+0.5),2)-($battlepart[8]*8)));
-                                if($walllevel == $totallvl){
+                        if ($type=='3')
+                        {
+                            if (($data['t7']-$traped7)>0){
+                                if (isset($empty)){
+                                    $info_ram = "".$ram_pic.",There is no wall to destroy.";
+                                } else
+                                    
+                                    if ($battlepart[8]>$battlepart[7]){
+                                        $info_ram = "".$ram_pic.",Wall destroyed.";
+                                        $database->setVillageLevel(
+                                            $data['to'],
+                                            ["f".$wallid, "f".$wallid."t"],
+                                            [0, 0]
+                                            );
+                                        $pop=$this->recountPop($data['to']);
+                                        
+                                }elseif ($battlepart[8]==0){
+                                    
                                     $info_ram = "".$ram_pic.",Wall was not damaged.";
                                 }else{
-                                    $info_ram = "".$ram_pic.",Wall damaged from level <b>".$walllevel."</b> to level <b>".$totallvl."</b>.";
-                                    $database->setVillageLevel($data['to'],"f".$wallid."",$totallvl);
+                                    $totallvl = round(sqrt(pow(($walllevel+0.5),2)-($battlepart[8]*8)));
+                                    if($walllevel == $totallvl){
+                                        $info_ram = "".$ram_pic.",Wall was not damaged.";
+                                    }else{
+                                        $info_ram = "".$ram_pic.",Wall damaged from level <b>".$walllevel."</b> to level <b>".$totallvl."</b>.";
+                                        $database->setVillageLevel($data['to'],"f".$wallid."",$totallvl);
+                                    }
                                 }
                             }
-                        }
-
-                        if (($data['t8']-$traped8)>0)
-                        {
-                            $pop=$this->recountPop($data['to']);
-                            if ($isoasis != 0) {
-                                $pop=10; //oasis cannot be destroy bt cata/ram
-                            }
-
-                            // village has been destroyed
-                            if ($pop<=0) {
-                                if ($can_destroy==1) {
-                                    $info_cat = "".$catp_pic.", Village already destroyed.";
-                                } else {
-                                    $info_cat = "".$catp_pic.", Village can\'t be destroyed.";
-                                }
-                            }
-                            else
+                            
+                            if (($data['t8']-$traped8)>0)
                             {
-                                // village stands, let's do the damage
-                                /**
-                                 * FIRST CATAPULTS ROW
-                                 */
-                                $basearray = $data['to'];
-                                $bdo = $database->getResourceLevel($basearray, false);
-                                $catapultTarget = $data['ctar1'];
-                                $catapultTarget2 = (isset($data['ctar2']) ? $data['ctar2'] : 0);
-
-                                $catapults1TargetRandom = ($catapultTarget == 0);
-                                $catapults2WillNotShoot = ($catapultTarget2 == 0);
-                                $catapults2TargetRandom = ($catapults2WillNotShoot || $catapultTarget2 == 99);
-
-                                // we're manually targetting 1st and/or 2nd row of catapults
-                                if (!$catapults1TargetRandom)
-                                {
-                                    $_catapultsTarget1Levels=array();
-                                    $__catapultsTarget1AltTargets=array();
-
-                                    // calculate targets for 1st rows of catapults
-                                    $j=0;
-                                    for ($i=1;$i<=41;$i++)
-                                    {
-                                        if ($i==41) $i=99;
-
-                                        // 1st row of catapults pre-selected target calculations, if needed
-                                        if (!$catapults1TargetRandom && $bdo['f'.$i.'t'] == $catapultTarget && $bdo['f'.$i] > 0 && $catapultTarget != 31 && $catapultTarget != 32 && $catapultTarget != 33)
-                                        {
-                                            $j++;
-                                            $_catapultsTarget1Levels[$j]=$bdo['f'.$i];
-                                            $__catapultsTarget1AltTargets[$j]=$i;
-                                        }
+                                $pop=$this->recountPop($data['to']);
+                                
+                                // village has been destroyed
+                                if ($pop<=0) {
+                                    if ($can_destroy==1) {
+                                        $info_cat = "".$catp_pic.", Village already destroyed.";
+                                    } else {
+                                        $info_cat = "".$catp_pic.", Village can\'t be destroyed.";
                                     }
-
-                                    // if we couldn't find a suitable target for 1st row of catapults,
-                                    // select a random target instead
-                                    if (!$catapults1TargetRandom) {
-                                        if ( count( $_catapultsTarget1Levels ) > 0 ) {
-                                            if ( max( $_catapultsTarget1Levels ) <= 0 ) {
+                                }
+                                else
+                                {
+                                    // village stands, let's do the damage
+                                    /**
+                                     * FIRST CATAPULTS ROW
+                                     */
+                                    $basearray = $data['to'];
+                                    $bdo = $database->getResourceLevel($basearray, false);
+                                    $catapultTarget = $data['ctar1'];
+                                    $catapultTarget2 = (isset($data['ctar2']) ? $data['ctar2'] : 0);
+                                    
+                                    $catapults1TargetRandom = ($catapultTarget == 0);
+                                    $catapults2WillNotShoot = ($catapultTarget2 == 0);
+                                    $catapults2TargetRandom = ($catapults2WillNotShoot || $catapultTarget2 == 99);
+                                    
+                                    // we're manually targetting 1st and/or 2nd row of catapults
+                                    if (!$catapults1TargetRandom)
+                                    {
+                                        $_catapultsTarget1Levels=array();
+                                        $__catapultsTarget1AltTargets=array();
+                                        
+                                        // calculate targets for 1st rows of catapults
+                                        $j=0;
+                                        for ($i=1;$i<=41;$i++)
+                                        {
+                                            if ($i==41) $i=99;
+                                            
+                                            // 1st row of catapults pre-selected target calculations, if needed
+                                            if (!$catapults1TargetRandom && $bdo['f'.$i.'t'] == $catapultTarget && $bdo['f'.$i] > 0 && $catapultTarget != 31 && $catapultTarget != 32 && $catapultTarget != 33)
+                                            {
+                                                $j++;
+                                                $_catapultsTarget1Levels[$j]=$bdo['f'.$i];
+                                                $__catapultsTarget1AltTargets[$j]=$i;
+                                            }
+                                        }
+                                        
+                                        // if we couldn't find a suitable target for 1st row of catapults,
+                                        // select a random target instead
+                                        if (!$catapults1TargetRandom) {
+                                            if ( count( $_catapultsTarget1Levels ) > 0 ) {
+                                                if ( max( $_catapultsTarget1Levels ) <= 0 ) {
+                                                    $catapultTarget = 0;
+                                                } else {
+                                                    $catapultTarget = $__catapultsTarget1AltTargets[ rand( 1, $j ) ];
+                                                }
+                                            } else {
                                                 $catapultTarget = 0;
-                                            } else {
-                                                $catapultTarget = $__catapultsTarget1AltTargets[ rand( 1, $j ) ];
+                                                $catapults1TargetRandom = true;
                                             }
-                                        } else {
-                                            $catapultTarget = 0;
-                                            $catapults1TargetRandom = true;
                                         }
                                     }
-                                }
-
-                                // 1st row of catapults set to target randomly
-                                if ($catapults1TargetRandom)
-                                {
-                                    $list=array();
-                                    for ($i=1;$i<=41;$i++)
+                                    
+                                    // 1st row of catapults set to target randomly
+                                    if ($catapults1TargetRandom)
                                     {
-                                        if ($i==41) $i=99;
-                                        if ($bdo['f'.$i] > 0 && $catapultTarget != 31 && $catapultTarget != 32 && $catapultTarget != 33)
+                                        $list=array();
+                                        for ($i=1;$i<=41;$i++)
                                         {
-                                            $list[] = $i;
+                                            if ($i==41) $i=99;
+                                            if ($bdo['f'.$i] > 0 && $catapultTarget != 31 && $catapultTarget != 32 && $catapultTarget != 33)
+                                            {
+                                                $list[] = $i;
+                                            }
                                         }
+                                        $catapultTarget = $list[ rand(0, count($list) - 1) ];
                                     }
-                                    $catapultTarget = $list[ rand(0, count($list) - 1) ];
-                                }
-
-                                /**
-                                 * resolve 1st row of catapults
-                                 */
-                                $village_destroyed = 0;
-                                $this->resolveCatapultsDestruction($bdo, $battlepart, $info_cat, $data, $catapultTarget, !$catapults2WillNotShoot, false, $catp_pic, $can_destroy, $isoasis, $village_destroyed);
-
-                                /**
-                                 * SECOND CATAPULTS ROW
-                                 */
-
-                                // we're manually targetting 2nd row of catapults
-                                if (!$catapults2TargetRandom)
-                                {
-                                    $_catapultsTarget2Levels=array();
-                                    $__catapultsTarget2AltTargets=array();
-
-                                    // calculate targets for 2nd rows of catapults
-                                    $j=0;
-                                    for ($i=1;$i<=41;$i++)
+                                    
+                                    /**
+                                     * resolve 1st row of catapults
+                                     */
+                                    $village_destroyed = 0;
+                                    $this->resolveCatapultsDestruction($bdo, $battlepart, $info_cat, $data, $catapultTarget, !$catapults2WillNotShoot, false, $catp_pic, $can_destroy, $isoasis, $village_destroyed);
+                                    
+                                    /**
+                                     * SECOND CATAPULTS ROW
+                                     */
+                                    
+                                    // we're manually targetting 2nd row of catapults
+                                    if (!$catapults2TargetRandom)
                                     {
-                                        if ($i==41) $i=99;
-
-                                        // 2nd row of catapults pre-selected target calculations, if needed
-                                        if (!$catapults2TargetRandom && !$catapults2WillNotShoot && $bdo['f'.$i.'t'] == $catapultTarget2 && $bdo['f'.$i] > 0 && $catapultTarget2 != 31 && $catapultTarget2 != 32 && $catapultTarget2 != 33)
+                                        $_catapultsTarget2Levels=array();
+                                        $__catapultsTarget2AltTargets=array();
+                                        
+                                        // calculate targets for 2nd rows of catapults
+                                        $j=0;
+                                        for ($i=1;$i<=41;$i++)
                                         {
-                                            $j++;
-                                            $_catapultsTarget2Levels[$j]=$bdo['f'.$i];
-                                            $__catapultsTarget2AltTargets[$j]=$i;
+                                            if ($i==41) $i=99;
+                                            
+                                            // 2nd row of catapults pre-selected target calculations, if needed
+                                            if (!$catapults2TargetRandom && !$catapults2WillNotShoot && $bdo['f'.$i.'t'] == $catapultTarget2 && $bdo['f'.$i] > 0 && $catapultTarget2 != 31 && $catapultTarget2 != 32 && $catapultTarget2 != 33)
+                                            {
+                                                $j++;
+                                                $_catapultsTarget2Levels[$j]=$bdo['f'.$i];
+                                                $__catapultsTarget2AltTargets[$j]=$i;
+                                            }
                                         }
-                                    }
-
-                                    // if we couldn't find a suitable target for 2nd row of catapults,
-                                    // select a random target instead
-                                    if (!$catapults2TargetRandom ) {
-                                        if ( count( $_catapultsTarget2Levels ) > 0 ) {
-                                            if ( max( $_catapultsTarget2Levels ) <= 0 ) {
+                                        
+                                        // if we couldn't find a suitable target for 2nd row of catapults,
+                                        // select a random target instead
+                                        if (!$catapults2TargetRandom ) {
+                                            if ( count( $_catapultsTarget2Levels ) > 0 ) {
+                                                if ( max( $_catapultsTarget2Levels ) <= 0 ) {
+                                                    $catapultTarget2 = 99;
+                                                } else {
+                                                    $catapultTarget2 = $__catapultsTarget2AltTargets[ rand( 1, $j ) ];
+                                                }
+                                            } else {
                                                 $catapultTarget2 = 99;
-                                            } else {
-                                                $catapultTarget2 = $__catapultsTarget2AltTargets[ rand( 1, $j ) ];
+                                                $catapults2TargetRandom = true;
                                             }
-                                        } else {
-                                            $catapultTarget2 = 99;
-                                            $catapults2TargetRandom = true;
                                         }
                                     }
-                                }
-
-                                // 2nd row of catapults set to target randomly
-                                if ($catapults2TargetRandom && !$catapults2WillNotShoot)
-                                {
-                                    $list=array();
-                                    for ($i=1;$i<=41;$i++)
+                                    
+                                    // 2nd row of catapults set to target randomly
+                                    if ($catapults2TargetRandom && !$catapults2WillNotShoot)
                                     {
-                                        if ($i==41) $i=99;
-                                        if ($bdo['f'.$i] > 0)
+                                        $list=array();
+                                        for ($i=1;$i<=41;$i++)
                                         {
-                                            $list[] = $i;
+                                            if ($i==41) $i=99;
+                                            if ($bdo['f'.$i] > 0)
+                                            {
+                                                $list[] = $i;
+                                            }
                                         }
+                                        $catapultTarget2 = $list[ rand(0, count($list) - 1) ];
                                     }
-                                    $catapultTarget2 = $list[ rand(0, count($list) - 1) ];
+                                    
+                                    /**
+                                     * resolve 2nd row of catapults
+                                     */
+                                    if (!$catapults2WillNotShoot) {
+                                        $this->resolveCatapultsDestruction($bdo, $battlepart, $info_cat, $data, $catapultTarget2, true, true, $catp_pic, $can_destroy, $isoasis, $village_destroyed);
+                                    }
+                                    
+                                    // clear resource levels cache, since we might have destroyed buildings/fields by now
+                                    call_user_func(get_class($database).'::clearResourseLevelsCache');
                                 }
-
-                                /**
-                                 * resolve 2nd row of catapults
-                                 */
-                                if (!$catapults2WillNotShoot) {
-                                    $this->resolveCatapultsDestruction($bdo, $battlepart, $info_cat, $data, $catapultTarget2, true, true, $catp_pic, $can_destroy, $isoasis, $village_destroyed);
-                                }
-
-                                // clear resource levels cache, since we might have destroyed buildings/fields by now
-                                call_user_func(get_class($database).'::clearResourseLevelsCache');
                             }
+                        } elseif (($data['t7']-$traped7)>0) {
+                            $info_ram = "".$ram_pic.",Hint: The ram does not work during a raid.";
                         }
-                    } elseif (($data['t7']-$traped7)>0) {
-                        $info_ram = "".$ram_pic.",Hint: The ram does not work during a raid.";
+                    }else{
+                        $can_destroy = 0;
                     }
 
                     //chiefing village
                     //there are senators
-                    if(($data['t9']-$dead9-$traped9)>0){
+                    if(($data['t9']-$dead9-$traped9)>0 && $isoasis==0){
                         if ($type=='3') {
 
                             $palacelevel = $database->getResourceLevel($from['wref']);
@@ -3050,10 +3062,8 @@ class Automation {
                         $village_destroyed = 0;
                     }
 
-                    if ($village_destroyed == 1) {
-                        if($can_destroy==1){
-                            $this->DelVillage($data['to']);
-                        }
+                    if ($village_destroyed == 1 && $can_destroy==1) {
+                        $this->DelVillage($data['to']);
                     }
                 }else{
                     //units attack string for battleraport

--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -2061,6 +2061,9 @@ class Automation {
                             $database->modifyHeroXp("experience",$defheroxp,$HeroID);
                         }
                     }
+                    
+                    // we don't need these two variables anymore
+                    unset($AttackerHeroID, $DefendersHeroID);
 
                     $database->modifyPoints(
                         $toF['owner'],

--- a/GameEngine/Building.php
+++ b/GameEngine/Building.php
@@ -494,6 +494,13 @@ class Building {
 			$uprequire = $this->resourceRequired($id,$village->resarray['f'.$id.'t']);
 			$time = time() + $uprequire['time'];
 			$bindicate = $this->canBuild($id,$village->resarray['f'.$id.'t']);
+			
+			// don't allow building above max levels and don't allow building if it's in demolition
+			if ($bindicate == 1 || $bindicate == 10 || $bindicate == 11) {
+			    header("Location: dorf2.php");
+			    exit;
+			}
+			
 			$loop = ($bindicate == 9 ? 1 : 0);
 			$loopsame = 0;
 			if($loop == 1) {
@@ -524,11 +531,6 @@ class Building {
 				}
 			}
 			$level = $database->getResourceLevel($village->wid);
-
-			// don't allow building above max levels
-            if ($level['f'.$id] + 1 > count(${'bid'.$village->resarray['f'.$id.'t']})) {
-                return;
-            }
 
 			if($session->access!=BANNED){
 			if($database->addBuilding($village->wid,$id,$village->resarray['f'.$id.'t'],$loop,$time+($loop==1?ceil(60/SPEED):0),0,$level['f'.$id] + 1 + count($database->getBuildingByField($village->wid,$id)))) {
@@ -607,7 +609,7 @@ class Building {
                 }
                 $uprequire = $this->resourceRequired( $id, $tid );
                 $time      = time() + $uprequire['time'];
-                $bindicate = $this->canBuild( $id, $village->resarray[ 'f' . $id . 't' ] );
+                $bindicate = $this->canBuild( $id, $tid );
                 $loop      = ( $bindicate == 9 ? 1 : 0 );
                 if ( $loop == 1 ) {
                     foreach ( $this->buildArray as $build ) {
@@ -629,6 +631,9 @@ class Building {
                         header( "Location: banned.php" );
                         exit;
                     }
+                } else {
+                    header("location: dorf2.php");
+                    exit;
                 }
             } else {
                 header( "Location: dorf2.php" );

--- a/GameEngine/Building.php
+++ b/GameEngine/Building.php
@@ -219,11 +219,11 @@ class Building {
      */
     
     private function redirect($tid){
-        if ( $tid >= 19 ) {
-            header( "Location: dorf2.php" );
+        if ($tid >= 19) {
+            header("Location: dorf2.php");
             exit;
         } else {
-            header( "Location: dorf1.php" );
+            header("Location: dorf1.php");
             exit;
         }
     }
@@ -482,14 +482,7 @@ class Building {
 				if($jobs['master'] == 0){
 					$database->modifyResource($village->wid,$uprequire['wood'],$uprequire['clay'],$uprequire['iron'],$uprequire['crop'],1);
 					}
-					if($jobs['field'] >= 19) {
-						header("Location: dorf2.php");
-						exit;
-					}
-					else {
-						header("Location: dorf1.php");
-						exit;
-					}
+					$this->redirect($jobs['field']);
 				}
 			}
 		}
@@ -541,14 +534,7 @@ class Building {
 			if($database->addBuilding($village->wid,$id,$village->resarray['f'.$id.'t'],$loop,$time+($loop==1?ceil(60/SPEED):0),0,$level['f'.$id] + 1 + count($database->getBuildingByField($village->wid,$id)))) {
 				$database->modifyResource($village->wid,$uprequire['wood'],$uprequire['clay'],$uprequire['iron'],$uprequire['crop'],0);
 				$logging->addBuildLog($village->wid,$this->procResType($village->resarray['f'.$id.'t']),($village->resarray['f'.$id]+($loopsame>0?2:1)),0);
-				if($id >= 19) {
-					header("Location: dorf2.php");
-					exit;
-				}
-				else {
-					header("Location: dorf1.php");
-					exit;
-				}
+				$this->redirect($id);
 			}
 			}else{
 			    header("Location: banned.php");

--- a/GameEngine/Database.php
+++ b/GameEngine/Database.php
@@ -5883,7 +5883,7 @@ References: User ID/Message ID, Mode
 	function modifyHeroXp($column,$value,$heroid) {
 	    list($column,$value,$heroid) = $this->escape_input($column,(int) $value,(int) $heroid);
 
-		$q = "UPDATE ".TB_PREFIX."hero SET $column = $column + $value WHERE uid=$heroid";
+		$q = "UPDATE ".TB_PREFIX."hero SET $column = $column + $value WHERE heroid=$heroid";
 		return mysqli_query($this->dblink,$q);
 	}
 

--- a/GameEngine/Game/WorldWonderName.php
+++ b/GameEngine/Game/WorldWonderName.php
@@ -10,7 +10,12 @@
 #################################################################################
 
 include("../Village.php");
-$database->submitWWname($_POST['vref'],$_POST['wwname']);
-header("Location: ../../build.php?id=99&n");
+if(isset($_POST['wwname']) && !empty($_POST['wwname']) && $village->natar){
+    $database->submitWWname($village->wid,$_POST['wwname']);
+    header("Location: ../../build.php?id=99&n");
+}else{
+    header("Location: ../../dorf2.php");
+}
+
 
 ?>

--- a/Templates/Build/15_1.tpl
+++ b/Templates/Build/15_1.tpl
@@ -19,7 +19,7 @@ if ($session->alliance) {
 
 if(!empty($_REQUEST["demolish"]) && $_REQUEST["c"] == $session->mchecker) {
 if($session->access != BANNED){
-    if($_REQUEST["type"] != null) {
+    if($_REQUEST["type"] != null && ($_REQUEST["type"] >= 19 && $_REQUEST["type"] <= 40 || $_REQUEST["type"] == 99)) {
         $type = $_REQUEST['type'];
         $demolish_permitted = $database->addDemolition($village->wid,$type);
         if ($demolish_permitted === true) {

--- a/Templates/Build/37_hero.tpl
+++ b/Templates/Build/37_hero.tpl
@@ -12,10 +12,11 @@
 include_once("GameEngine/Data/hero_full.php");
 global $database; 
 
-if (isset($_POST['name'])) { 
-	$_POST['name'] = stripslashes($_POST['name']);
-	mysqli_query($GLOBALS['link'],"UPDATE ".TB_PREFIX."hero SET `name`='".($database->escape($_POST['name']))."' where `uid`='".$database->escape($session->uid)."' AND dead = 0") or die("ERROR:".mysqli_error($database->dblink));   
-    echo "".NAME_CHANGED.""; 
+if (isset($_POST['name']) && !empty($_POST['name'])) { 
+    $_POST['name'] = $database->escape(stripslashes($_POST['name']));
+	mysqli_query($GLOBALS['link'],"UPDATE ".TB_PREFIX."hero SET `name`='".$_POST['name']."' where `uid`='".$database->escape($session->uid)."' AND dead = 0") or die("ERROR:".mysqli_error($database->dblink));   
+	$hero_info['name'] = $_POST['name'];
+	echo "".NAME_CHANGED.""; 
 }
 ?>
 

--- a/Templates/Build/ww.tpl
+++ b/Templates/Build/ww.tpl
@@ -20,7 +20,6 @@
 <h1><?php echo WONDER;?> <br /><span class="level"><?php echo LEVEL;?> <?php echo $village->resarray['f'.$id];?></span></h1>
 <p class="build_desc"><?php echo WONDER_DESC;?></p>
 <form action="GameEngine/Game/WorldWonderName.php" method="POST">
-<input type="hidden" name="vref" value="<?php echo $_SESSION['wid']; ?>" />
 <?php
 $vref = $_SESSION['wid'];
 $wwname = $database->getWWName($vref);
@@ -37,7 +36,7 @@ echo ''.WORLD_WONDER_NOTCHANGE_NAME.'.
     </form>
 	<?php
     if(isset($_GET['n'])) {
-		echo '<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<font color="Red"><b>'.WORLD_WONDER_NAME_CHANGED.'.</b></font>';
+		echo '<div style="text-align: center"><font color="Red"><b>'.WORLD_WONDER_NAME_CHANGED.'.</b></font></div><br />';
 		  }
 		  ?>
 

--- a/build.php
+++ b/build.php
@@ -22,8 +22,8 @@ if ( isset( $_GET['newdid'] ) ) {
     header( "Location: " . $_SERVER['PHP_SELF'] . ( isset( $_GET['id'] ) ? '?id=' . $_GET['id'] : ( isset( $_GET['gid'] ) ? '?gid=' . $_GET['gid'] : '' ) ) );
     exit;
 }
-if ( isset( $_GET['id'] ) && $_GET['id'] == 99 && $village->natar == 0 ) {
-    header( "Location: dorf2.php" );
+if (isset($_GET['id']) && ($_GET['id'] < 1 || $_GET['id'] > 40 && ($_GET['id'] == 99 && $village->natar == 0 || $_GET['id'] != 99))) {
+    header("Location: dorf2.php");
     exit;
 }
 


### PR DESCRIPTION
Fixed the issue #446.

The hero experience was distributed incorrectly if the defender(s)/attacker had created more than 1 hero. Now, only the attacking hero/defending heroes will receive the experience (even if deads).

Added two controls to prevent the execution of some instructions (for catas and rams) if the attacked target is an oasis. (If you want to see what i've changed, you should click on "Split" instead of using "Unified", because GitHub shows it "incorrectly").